### PR TITLE
Try to use setuptools if possible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 import sys
 import subprocess
-from distutils.core import setup
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 
 # PY3 = sys.version_info.major >= 3  # major is not available in python2.6


### PR DESCRIPTION
This allows you to use

```
python setup.py develop
```

It does not install the module, but creates a link to the source in the site-packages directory. When combined with a virtualenv, this allows you to run the examples and test the code, without having to install it again after every change.
