### PR TITLE
pip3 installation preferred as apt is not longer supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Make sure you are using the lastest version of Raspbian:
     $ sudo apt-get update
     $ sudo apt-get upgrade
 
-Install `pifacedigitalio` with the following commands:
+Install `pifacedigitalio` with the following command:
 
     Python 3:
     $ sudo pip3 install pifacedigitalio

--- a/README.md
+++ b/README.md
@@ -20,9 +20,14 @@ Make sure you are using the lastest version of Raspbian:
     $ sudo apt-get update
     $ sudo apt-get upgrade
 
-Install `pifacedigitalio` (for Python 3 and 2) with the following command:
+Install `pifacedigitalio` with the following commands:
 
-    $ sudo apt-get install python{,3}-pifacedigitalio
+    Python 3:
+    $ sudo pip3 install pifacedigitalio
+
+    Notice 1: Installation from Raspbian repository with apt is not longer the preferred way, take a look into [https://github.com/piface/pifacecommon/issues/27#issuecomment-451400154](issue 27)
+    
+    Notice 2: Python 2 support is "end-of-life" since Jan 2020, refer to https://www.python.org/doc/sunset-python-2/
 
 Test by running the `blink.py` program:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,7 +12,7 @@ Install ``pifacedigitalio`` with the following command:
     Python 3:
     $ sudo pip3 install pifacedigitalio
 
-    Notice 1: Installation from Raspbian repository with apt is not longer the preferred way, take a look into [https://github.com/piface/pifacecommon/issues/27#issuecomment-451400154](issue 27)
+    Notice 1: Installation from Raspbian repository with apt is not longer the preferred way, take a look into `(pifacecommon issue #27) <https://github.com/piface/pifacecommon/issues/27#issuecomment-451400154/>`_
     
     Notice 2: Python 2 support is "end-of-life" since Jan 2020, refer to https://www.python.org/doc/sunset-python-2/
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,9 +7,14 @@ Make sure you are using the lastest version of Raspbian::
     $ sudo apt-get update
     $ sudo apt-get upgrade
 
-Install ``pifacedigitalio`` (for Python 3 and 2) with the following command::
+Install ``pifacedigitalio`` with the following command:
 
-    $ sudo apt-get install python{,3}-pifacedigitalio
+    Python 3:
+    $ sudo pip3 install pifacedigitalio
+
+    Notice 1: Installation from Raspbian repository with apt is not longer the preferred way, take a look into [https://github.com/piface/pifacecommon/issues/27#issuecomment-451400154](issue 27)
+    
+    Notice 2: Python 2 support is "end-of-life" since Jan 2020, refer to https://www.python.org/doc/sunset-python-2/
 
 Test by running the ``blink.py`` program::
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,7 +12,7 @@ Install ``pifacedigitalio`` with the following command:
     Python 3:
     $ sudo pip3 install pifacedigitalio
 
-    Notice 1: Installation from Raspbian repository with apt is not longer the preferred way, take a look into `(pifacecommon issue #27) <https://github.com/piface/pifacecommon/issues/27#issuecomment-451400154/>`_
+    Notice 1: Installation from Raspbian repository with apt is not longer the preferred way, take a look into `pifacecommon issue #27 <https://github.com/piface/pifacecommon/issues/27#issuecomment-451400154/>`_
     
     Notice 2: Python 2 support is "end-of-life" since Jan 2020, refer to https://www.python.org/doc/sunset-python-2/
 


### PR DESCRIPTION
This will "fix" the kind of installation and issue #39