### PR TITLE
Add Content-length to simplewebcontrol example to increase compatibility.

### DIFF
--- a/examples/simplewebcontrol.py
+++ b/examples/simplewebcontrol.py
@@ -47,14 +47,25 @@ class PiFaceWebHandler(http.server.BaseHTTPRequestHandler):
             new_output_value = query_components["output_port"][0]
             output_value = self.set_output_port(new_output_value, output_value)
 
+        # create the JSON content
+        content = bytes(JSON_FORMAT.format(
+            input=input_value,
+            output=output_value,
+        ), 'UTF-8')
+
         # reply with JSON
         self.send_response(200)
         self.send_header("Content-type", "application/json")
+        self.send_header("Content-length", str(len(content)))
         self.end_headers()
-        self.wfile.write(bytes(JSON_FORMAT.format(
-            input=input_value,
-            output=output_value,
-        ), 'UTF-8'))
+        self.wfile.write(content)
+
+    # Uncomment this function if you want to access this PiFace server
+    # from a web app (Web app is loaded from another server, not from this PiFace server).
+    # Normally this is not allowed. Uncomment this to allow this scenario.
+    #def end_headers (self):
+    #    self.send_header('Access-Control-Allow-Origin', '*')
+    #    http.server.BaseHTTPRequestHandler.end_headers(self)
 
     def set_output_port(self, new_value, old_value=0):
         """Sets the output port value to new_value, defaults to old_value."""


### PR DESCRIPTION
I have add the Content-length property with the correct length of the JSON content to increase the browser and HTTP client compatibility. I use the simplewebcontrol server example to access the PiFace's input and output states from a game developed with the godot engine. Without that fix the HTTPRequest node from the Godot engine has discard the received JSON content. Maybe there exist other HTTP clients and browsers which maybe also ignore the JSON content if the Content-length is not defined. I think this pull request is useful to increase the HTTP client compatibility.

I also overwrite the function end_headers() and add the header property Access-Control-Allow-Origin with the value *. But I have comment this function out. So per default this is not activated. You can uncomment this function if you want to access this PiFace server (simplewebcontrol) from a web app (Web app is loaded from another server, not from this PiFace server). Normally this is not allowed. Uncomment this to allow this scenario. I think this scenario is not so common, so I only leave the necessary changes as comment at the code.


